### PR TITLE
feat(models): add refs to habitCompletion schema

### DIFF
--- a/server/models/habitCompletion.model.js
+++ b/server/models/habitCompletion.model.js
@@ -5,10 +5,12 @@ const habitCompletionSchema = new Schema(
   {
     habitId: {
       type: mongoose.Schema.ObjectId,
+      ref: "Habit",
       required: true,
     },
     userId: {
       type: mongoose.Schema.ObjectId,
+      ref: "User",
       required: true,
     },
     dateOfCompletion: {


### PR DESCRIPTION
add 'ref' properties to the userid and habitid fields in the habitCompletion model.

this establishes a formal schema-level relationship with the user and habit models, respectively. this change is necessary for the use of the mongoose method '.populate()' which will simplify queries and improve performance by avoiding manual lookups.